### PR TITLE
chore: prilux-vial-ui to 0.0.110

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.355
 - name: prilux-vial-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.109
+  version: 0.0.110
 - name: priluxswiftlibrary
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.155


### PR DESCRIPTION
chore: Promote prilux-vial-ui to version 0.0.110